### PR TITLE
don't logs uid and cookie

### DIFF
--- a/presentation/src/main/java/danggai/app/presentation/ui/main/MainViewModel.kt
+++ b/presentation/src/main/java/danggai/app/presentation/ui/main/MainViewModel.kt
@@ -298,15 +298,8 @@ class MainViewModel @Inject constructor(
     }
 
     fun initUI() {
-        preference.getStringUid().let {
-            log.e(it)
-            sfUid.value = it
-        }
-
-        preference.getStringCookie().let {
-            log.e(it)
-            sfCookie.value = it
-        }
+        sfUid.value = preference.getStringUid()
+        sfCookie.value = preference.getStringCookie()
 
         preference.getDailyNoteSettings().let {
             sfServer.value = it.server


### PR DESCRIPTION
printing uid and cookie on logs is not good for security because it can be readed by anyone that has access to logs via `adb` or `android.permission.READ_LOGS`
