### PR TITLE
출석체크 알림의 닉네임 표시, 영어 개척자 용어 수정

### DIFF
--- a/presentation/src/main/java/danggai/app/presentation/worker/CheckInWorker.kt
+++ b/presentation/src/main/java/danggai/app/presentation/worker/CheckInWorker.kt
@@ -382,19 +382,19 @@ class CheckInWorker @AssistedInject constructor(
             Constant.NotiType.CHECK_IN_HONKAI_3RD_SUCCESS
             -> String.format(applicationContext.getString(R.string.push_msg_checkin_success_honkai), account.nickname)
             Constant.NotiType.CHECK_IN_HONKAI_SR_SUCCESS
-            -> String.format(applicationContext.getString(R.string.push_msg_checkin_success_honkai_sr), account.nickname)
+            -> String.format(applicationContext.getString(R.string.push_msg_checkin_success_honkai_sr), account.honkai_sr_nickname)
             Constant.NotiType.CHECK_IN_GENSHIN_ALREADY
             -> String.format(applicationContext.getString(R.string.push_msg_checkin_already_genshin), account.nickname)
             Constant.NotiType.CHECK_IN_HONKAI_3RD_ALREADY
             -> String.format(applicationContext.getString(R.string.push_msg_checkin_already_honkai), account.nickname)
             Constant.NotiType.CHECK_IN_HONKAI_SR_ALREADY
-            -> String.format(applicationContext.getString(R.string.push_msg_checkin_already_honkai_sr), account.nickname)
+            -> String.format(applicationContext.getString(R.string.push_msg_checkin_already_honkai_sr), account.honkai_sr_nickname)
             Constant.NotiType.CHECK_IN_GENSHIN_FAILED
             -> String.format(applicationContext.getString(R.string.push_msg_checkin_failed_genshin), account.nickname)
             Constant.NotiType.CHECK_IN_HONKAI_3RD_FAILED
             -> String.format(applicationContext.getString(R.string.push_msg_checkin_failed_honkai), account.nickname)
             Constant.NotiType.CHECK_IN_HONKAI_SR_FAILED
-            -> String.format(applicationContext.getString(R.string.push_msg_checkin_failed_honkai_sr), account.nickname)
+            -> String.format(applicationContext.getString(R.string.push_msg_checkin_failed_honkai_sr), account.honkai_sr_nickname)
             Constant.NotiType.CHECK_IN_GENSHIN_ACCOUNT_NOT_FOUND,
             Constant.NotiType.CHECK_IN_HONKAI_3RD_ACCOUNT_NOT_FOUND,
             Constant.NotiType.CHECK_IN_HONKAI_SR_ACCOUNT_NOT_FOUND

--- a/presentation/src/main/res/values-ko/strings.xml
+++ b/presentation/src/main/res/values-ko/strings.xml
@@ -182,9 +182,9 @@
     <string name="push_genshin_checkin_title">원신 출석 알림</string>
     <string name="push_genshin_checkin_description">원신 출석 결과를 여행자에게 알려주기 위해 발송하는 알림이야!</string>
     <string name="push_honkai_3rd_checkin_title">붕괴3rd 출석 알림</string>
-    <string name="push_honkai_3rd_checkin_description">붕괴3rd 출석 결과를 여행자에게 알려주기 위해 발송하는 알림이야!</string>
+    <string name="push_honkai_3rd_checkin_description">붕괴3rd 출석 결과를 함장에게 알려주기 위해 발송하는 알림이야!</string>
     <string name="push_honkai_sr_checkin_title">붕괴: 스타레일 출석 알림</string>
-    <string name="push_honkai_sr_checkin_description">붕괴: 스타레일 출석 결과를 여행자에게 알려주기 위해 발송하는 알림이야!</string>
+    <string name="push_honkai_sr_checkin_description">붕괴: 스타레일 출석 결과를 개척자에게 알려주기 위해 발송하는 알림이야!</string>
     <string name="push_msg_checkin_success_genshin">%s! 오늘 출석체크 해왔어!</string>
     <string name="push_msg_checkin_success_honkai">오늘 자 출석체크가 완료됐어, %s~</string>
     <string name="push_msg_checkin_success_honkai_sr">오늘 자 출석체크가 완료됐어, %s~</string>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -205,9 +205,9 @@
     <string name="push_genshin_checkin_title">Genshin Impact Check-in Notification</string>
     <string name="push_genshin_checkin_description">This is a notification to inform travelers of the daily check-in result of Genshin Impact!</string>
     <string name="push_honkai_3rd_checkin_title">Honkai Impact 3rd Check-in Notification</string>
-    <string name="push_honkai_3rd_checkin_description">This is a notification to inform travelers of the daily check-in result of Honkai Impact 3rd!</string>
+    <string name="push_honkai_3rd_checkin_description">This is a notification to inform captains of the daily check-in result of Honkai Impact 3rd!</string>
     <string name="push_honkai_sr_checkin_title">Honkai Impact: Star Rail Check-in Notification</string>
-    <string name="push_honkai_sr_checkin_description">This is a notification to inform travelers of the daily check-in result of Honkai Impact: Star Rail!</string>
+    <string name="push_honkai_sr_checkin_description">This is a notification to inform pioneers of the daily check-in result of Honkai Impact: Star Rail!</string>
     <string name="push_msg_checkin_success_genshin">%s! checked attendance today!</string>
     <string name="push_msg_checkin_success_honkai">I completed today\'s check in, %s~</string>
     <string name="push_msg_checkin_success_honkai_sr">I completed today\'s check in, %s~</string>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -195,7 +195,7 @@
     <string name="push_msg_resin_noti_custom">%s! Your resin is over %d!</string>
 
     <string name="push_trail_power_noti_title">Trainblaze Power Notification</string>
-    <string name="push_trail_power_noti_description">This is a notification sent to inform pioneers of each trainblaze power!</string>
+    <string name="push_trail_power_noti_description">This is a notification sent to inform trailblazers of each trainblaze power!</string>
     <string name="push_msg_trail_power_noti_over_40">Hello, %s! Your Trainblaze Power is over %d!</string>
     <string name="push_msg_trail_power_noti_over_160">Hello, %s! Your Trainblaze Power is over %d!</string>
     <string name="push_msg_trail_power_noti_over_170">Hello, %s! Your Trainblaze Power is over %d!</string>
@@ -207,7 +207,7 @@
     <string name="push_honkai_3rd_checkin_title">Honkai Impact 3rd Check-in Notification</string>
     <string name="push_honkai_3rd_checkin_description">This is a notification to inform captains of the daily check-in result of Honkai Impact 3rd!</string>
     <string name="push_honkai_sr_checkin_title">Honkai Impact: Star Rail Check-in Notification</string>
-    <string name="push_honkai_sr_checkin_description">This is a notification to inform pioneers of the daily check-in result of Honkai Impact: Star Rail!</string>
+    <string name="push_honkai_sr_checkin_description">This is a notification to inform trailblazers of the daily check-in result of Honkai Impact: Star Rail!</string>
     <string name="push_msg_checkin_success_genshin">%s! checked attendance today!</string>
     <string name="push_msg_checkin_success_honkai">I completed today\'s check in, %s~</string>
     <string name="push_msg_checkin_success_honkai_sr">I completed today\'s check in, %s~</string>
@@ -222,7 +222,7 @@
 
     <string name="push_expedition_title">Expedition Done Notification</string>
     <string name="push_expedition_description_genshin">This is a notification sent to travelers when the expedition is complete!</string>
-    <string name="push_expedition_description_honkai_sr">This is a notification sent to pioneers when the expedition is complete!</string>
+    <string name="push_expedition_description_honkai_sr">This is a notification sent to trailblazers when the expedition is complete!</string>
     <string name="push_msg_expedition_done_genshin">%s! All the expedition is complete! (Genshin)</string>
     <string name="push_msg_expedition_done_honkai_sr">%s! All the expedition is complete! (Honkai: Star Rail)</string>
 
@@ -245,11 +245,11 @@
     <string name="hint_cookie">Enter HoYoLAB\'s cookie!</string>
     <string name="hint_uid">Enter uid!</string>
     <string name="hint_nickname_genshin">Enter name of traveler!</string>
-    <string name="hint_nickname_honkai_sr">Enter name of pioneer!</string>
+    <string name="hint_nickname_honkai_sr">Enter name of trailblazer!</string>
 
     <string name="invalid_user_info">You can\'t use it\nwithout user information!</string>
 
-    <string name="pioneer">Pioneer</string>
+    <string name="pioneer">Trailblazer</string>
     <string name="captain">Captain</string>
     <string name="traveler">Traveler</string>
 


### PR DESCRIPTION
- 붕괴: 스타레일 출석체크 알림에서 원신 닉네임이 나오던 것을 고침
- 붕괴 3rd, 붕괴: 스타레일 출석체크 설명에서 여행자라고 나오던 것을 고침

- 붕괴: 스타레일의 개척자에 해당하는 영어 문자열을 pioneer에서 trailblazer로 수정
- 붕괴 3rd, 붕괴: 스타레일 출석체크 영어 설명에서 traveler라고 나오던 것을 고침